### PR TITLE
Updated phantomjs to 1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"grunt": "~0.4.2"
 	},
 	"dependencies": {
-		"grunt-lib-phantomjs": "0.7.x",
+		"grunt-lib-phantomjs": "1.1.x",
 		"mocha": "1.12.x",
 		"chai": "1.8.x",
 		"express": "4.5.x",


### PR DESCRIPTION
Phantomjs 0.7 is broken on MacOS 10.12 and maybe other versions. I've tested with PhantomJS 1.1.0 which seems to work fine.